### PR TITLE
Validate query parameters with annotation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,6 +62,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 

--- a/backend/src/main/java/com/hoppylearn/controller/DeckController.java
+++ b/backend/src/main/java/com/hoppylearn/controller/DeckController.java
@@ -4,6 +4,7 @@ import com.hoppylearn.model.entity.Deck;
 import com.hoppylearn.model.request.DeckRequest;
 import com.hoppylearn.model.response.DeckResponse;
 import com.hoppylearn.service.DeckService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/v1")
@@ -24,7 +27,7 @@ public class DeckController {
     }
 
     @PostMapping("/deck")
-    public ResponseEntity<DeckResponse> handlePost(@RequestBody DeckRequest deckRequest) {
+    public ResponseEntity<DeckResponse> handlePost(@Valid @RequestBody DeckRequest deckRequest) {
         try {
             Deck deck = deckService.createDeck(deckRequest.getDeckName());
             if (deck == null) {

--- a/backend/src/main/java/com/hoppylearn/model/request/DeckRequest.java
+++ b/backend/src/main/java/com/hoppylearn/model/request/DeckRequest.java
@@ -1,5 +1,6 @@
 package com.hoppylearn.model.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeckRequest {
+    @NotBlank(message="Deck name should be present")
     private String deckName;
 }

--- a/backend/src/test/java/com/hoppylearn/controller/DeckControllerIntegrationTest.java
+++ b/backend/src/test/java/com/hoppylearn/controller/DeckControllerIntegrationTest.java
@@ -1,0 +1,42 @@
+package com.hoppylearn.controller;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.hoppylearn.controller.DeckController;
+import com.hoppylearn.model.request.DeckRequest;
+import com.hoppylearn.service.DeckService;
+
+@WebMvcTest(DeckController.class)
+public class DeckControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private DeckService deckService;
+
+    @Test
+    void whenDeckNameIsWhiteSpace_thenValidationFails() throws Exception {
+        // Arrange
+        DeckRequest request = new DeckRequest();
+        request.setDeckName("  ");
+
+        // Act & Assert
+        mockMvc.perform(post("/v1/deck")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
- Enforce Request payload validation: @valid should be added at controller level to enable/trigger validation constraints ( @NotBlank, @Size, @Max, etc)

Remy, I realized that we have not discussed what fields to be validated (todo: NotBlank doesn’t seem to work for name query parameter). -,- so this PR shows how to use jakarta validation constraints only.
I am not proud of my integration test. :')  I believe once we merge your exception handling, I can improve assertion part ( for example, comparing customized error messages. )

<img width="1618" height="926" alt="image" src="https://github.com/user-attachments/assets/f5baae1c-420f-4a8a-8af7-a9b7a3c6270e" />



