### PR TITLE
Clean up - Use requiredArgsConstructor to remove repeated autowired annotations

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -76,6 +76,22 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+		<plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.10.1</version>
+            <configuration>
+                <source>21</source>
+                <target>21</target>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.42</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
 			
 		</plugins>
 	</build>

--- a/backend/src/main/java/com/hoppylearn/controller/DeckController.java
+++ b/backend/src/main/java/com/hoppylearn/controller/DeckController.java
@@ -8,7 +8,6 @@ import com.hoppylearn.model.request.DeckRequest;
 import com.hoppylearn.model.response.DeckResponse;
 import com.hoppylearn.service.DeckService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -18,17 +17,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/v1")
+@RequiredArgsConstructor
 public class DeckController {
 
     private final DeckService deckService;
-
-    @Autowired
-    public DeckController(DeckService deckService) {
-        this.deckService = deckService;
-    }
 
     @PostMapping("/decks")
     public ResponseEntity<DeckResponse> handlePost(@Valid @RequestBody DeckRequest deckRequest) {

--- a/backend/src/main/java/com/hoppylearn/service/DeckService.java
+++ b/backend/src/main/java/com/hoppylearn/service/DeckService.java
@@ -5,56 +5,17 @@ import com.hoppylearn.model.paramaters.DeckSearchParams;
 
 import java.util.List;
 
-/**
- * Service interface for business logic related to Decks
- */
 public interface DeckService {
 
-    /**
-     * Create a new deck
-     * 
-     * @param name The name of the deck
-     * @return The created deck
-     */
     Deck createDeck(String name);
 
-    /**
-     * Get a deck by ID
-     * 
-     * @param id The deck ID
-     * @return Optional containing the deck if found
-     */
     Deck getDeck(String id);
 
-    /**
-     * Get a deck by name
-     * 
-     * @param searchParams search paramaters to filter decks
-     * @return List of decks matching the search parameters
-     */
     List<Deck> getDecks(DeckSearchParams searchParams);
 
-    /**
-     * Delete a deck
-     * 
-     * @param id The deck ID
-     * @return true if deleted, false if not found
-     */
     boolean deleteDeck(String id);
 
-    /**
-     * Check if deck exists
-     * 
-     * @param id The deck ID
-     * @return true if exists, false otherwise
-     */
     boolean deckExistsById(String id);
 
-    /**
-     * Check if deck exists by name
-     * 
-     * @param name The name of the deck
-     * @return true if exists, false otherwise
-     */
     boolean deckExistsByName(String name);
 }


### PR DESCRIPTION
[No functional change]
@RequiredArgsConstructor generates a constructor with 'final' and 'non null' fields.
Why do I want to use this annotation ? because this will help reduce boilerplate code in the future.
For example, when we add more class member variables, we dont have to 1. pass them as a argument in a constructor and 2. add autowired annotation.  

<img width="1237" height="451" alt="image" src="https://github.com/user-attachments/assets/8d5957f9-79a8-404b-a70c-4d1311475d44" />

-,- I spent several hours for this cleanup because VScode Java Langauge Server did not recognize lombok even though maven clean package can correctly generate DeckController class file. Let me know if your vscode marks the class member variable as an error.